### PR TITLE
Add git, since it is needed for Julia's package manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM debian:jessie
 
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends ca-certificates git \
+	&& rm -rf /var/lib/apt/lists/*
+
 ENV JULIA_PATH /usr/local/julia
 ENV JULIA_VERSION 0.3.8
 


### PR DESCRIPTION
fixes #1

Size comparison using `--no-install-recommends` and keeping `ca-certificates` (~5MB for ca-certs):
```console
REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
julia               latest              fdc4b506074d        6 minutes ago       323.3 MB
julia               0.3                 3e250d086241        13 days ago         254.7 MB
```

Just to be certain, it doesn't need any of the other scms, like `bzr`, `mercurial`, or `subversion`?