### PR TITLE
The Julia package manager in 0.5 no longer requires git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:jessie
 
 RUN apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates git \
+	&& apt-get install -y --no-install-recommends ca-certificates \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV JULIA_PATH /usr/local/julia


### PR DESCRIPTION
It calls into libgit2 which is included in the binaries.