### PR TITLE
build-essential needed to install Julia packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM debian:jessie
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends ca-certificates \
+	&& apt-get install -y --no-install-recommends build-essential \
 	&& rm -rf /var/lib/apt/lists/*
 
 ENV JULIA_PATH /usr/local/julia


### PR DESCRIPTION
If we don't add build-essential Pkg.Add with fail often, for instance it failed to install ODBC package because it depended on DecFP , debugging this was time consuming so I think it makes more sense to just add build-essential to the docker container