### PR TITLE
Update s3 URLS to new DNS home

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ ENV JULIA_VERSION 0.5.2
 
 RUN mkdir $JULIA_PATH \
 	&& apt-get update && apt-get install -y curl \
-	&& curl -sSL "https://julialang.s3.amazonaws.com/bin/linux/x64/${JULIA_VERSION%[.-]*}/julia-${JULIA_VERSION}-linux-x86_64.tar.gz" -o julia.tar.gz \
-	&& curl -sSL "https://julialang.s3.amazonaws.com/bin/linux/x64/${JULIA_VERSION%[.-]*}/julia-${JULIA_VERSION}-linux-x86_64.tar.gz.asc" -o julia.tar.gz.asc \
+	&& curl -sSL "https://julialang-s3.julialang.org/bin/linux/x64/${JULIA_VERSION%[.-]*}/julia-${JULIA_VERSION}-linux-x86_64.tar.gz" -o julia.tar.gz \
+	&& curl -sSL "https://julialang-s3.julialang.org/bin/linux/x64/${JULIA_VERSION%[.-]*}/julia-${JULIA_VERSION}-linux-x86_64.tar.gz.asc" -o julia.tar.gz.asc \
 	&& export GNUPGHOME="$(mktemp -d)" \
 # http://julialang.org/juliareleases.asc
 # Julia (Binary signing key) <buildbot@julialang.org>


### PR DESCRIPTION
We recently added a fastly caching layer between our S3 bucket and the outside world, this updates the DNS name to the proper value.