### PR TITLE
Add support for multiple architectures

### DIFF
--- a/.architectures-lib
+++ b/.architectures-lib
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+_awkArch() {
+	local version="$1"; shift
+	local awkExpr="$1"; shift
+	awk "$@" "/^#|^\$/ { next } $awkExpr" "$version/release-architectures"
+}
+
+dpkgArches() {
+	local version="$1"; shift
+	_awkArch "$version" '{ print $2 }'
+}
+
+hasBashbrewArch() {
+	local version="$1"; shift
+	local bashbrewArch="$1"; shift
+	_awkArch "$version" 'BEGIN { exitCode = 1 } $1 == bashbrewArch { exitCode = 0 } END { exit exitCode }' -v bashbrewArch="$bashbrewArch"
+}
+
+dpkgToJuliaTarArch() {
+	local version="$1"; shift
+	local dpkgArch="$1"; shift
+	_awkArch "$version" '$2 == dpkgArch { print $3; exit }' -v dpkgArch="$dpkgArch"
+}
+
+dpkgToJuliaDirArch() {
+	local version="$1"; shift
+	local dpkgArch="$1"; shift
+	_awkArch "$version" '$2 == dpkgArch { print $4; exit }' -v dpkgArch="$dpkgArch"
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,22 @@
 language: bash
 services: docker
 
+env:
+  - ARCH=
+  - ARCH=i386
+
 install:
   - git clone https://github.com/docker-library/official-images.git ~/official-images
 
 before_script:
   - env | sort
   - image='julia'
+  - |
+    if [ -n "$ARCH" ]; then
+        from="$(awk '$1 == toupper("FROM") { print $2 }' Dockerfile)"
+        docker pull "$ARCH/$from"
+        docker tag "$ARCH/$from" "$from"
+    fi
 
 script:
   - travis_retry docker build -t "$image" .

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -13,20 +13,14 @@ ENV JULIA_PATH /usr/local/julia
 ENV JULIA_GPG 3673DF529D9049477F76B37566E3C7DC03D6E495
 
 # https://julialang.org/downloads/
-ENV JULIA_VERSION 0.6.0
+ENV JULIA_VERSION %%JULIA_VERSION%%
 
 RUN set -ex; \
 	\
 # https://julialang.org/downloads/#julia-command-line-version
-# https://julialang-s3.julialang.org/bin/checksums/julia-0.6.0.sha256
+# https://julialang-s3.julialang.org/bin/checksums/julia-%%JULIA_VERSION%%.sha256
 # this "case" statement is generated via "update.sh"
-	dpkgArch="$(dpkg --print-architecture)"; \
-	case "${dpkgArch##*-}" in \
-		amd64) tarArch='x86_64'; dirArch='x64'; sha256='3a27ea78b06f46701dc4274820d9853789db205bce56afdc7147f7bd6fa83e41' ;; \
-		armhf) tarArch='arm'; dirArch='arm'; sha256='7515f5977b2aac0cea1333ef249b3983928dee76ea8eb3de9dd6a7cdfbd07d2d' ;; \
-		i386) tarArch='i686'; dirArch='x86'; sha256='bfebd2ef38c25ce72dd6661cdd8a6f509800492a4d250c2908f83e791c0a444a' ;; \
-		*) echo >&2 "error: current architecture ($dpkgArch) does not have a corresponding Julia binary release"; exit 1 ;; \
-	esac; \
+	%%ARCH-CASE%%; \
 	\
 	curl -fL -o julia.tar.gz     "https://julialang-s3.julialang.org/bin/linux/${dirArch}/${JULIA_VERSION%[.-]*}/julia-${JULIA_VERSION}-linux-${tarArch}.tar.gz"; \
 	curl -fL -o julia.tar.gz.asc "https://julialang-s3.julialang.org/bin/linux/${dirArch}/${JULIA_VERSION%[.-]*}/julia-${JULIA_VERSION}-linux-${tarArch}.tar.gz.asc"; \

--- a/release-architectures
+++ b/release-architectures
@@ -1,0 +1,9 @@
+# see https://julialang.org/downloads/#julia-command-line-version
+
+# bashbrew-arch dpkg-arch julia-tar-arch julia-dir-arch
+amd64   amd64   x86_64  x64
+arm32v7 armhf   arm     arm
+i386    i386    i686    x86
+
+# ppc64le appears to be "0.6.0-rc3"-only as of 2017-08-24
+#ppc64le ppc64el ppc64le ppc64le

--- a/update.sh
+++ b/update.sh
@@ -1,9 +1,44 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -Eeuo pipefail
 
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
-pattern='.*\/julia-([0-9]+\.[0-9]+\.[0-9]+)-linux-x86_64\.tar\.gz.*'
-version=$(curl -sSL 'http://julialang.org/downloads/' | sed -rn "s/${pattern}/\1/gp")
 
-sed -ri 's/^(ENV JULIA_VERSION) .*/\1 '"$version"'/' "Dockerfile"
+source '.architectures-lib'
 
+# see http://stackoverflow.com/a/2705678/433558
+sed_escape_rhs() {
+	echo "$@" | sed -e 's/[\/&]/\\&/g' | sed -e ':a;N;$!ba;s/\n/\\n/g'
+}
+
+for version in '.'; do
+	pattern='.*/julia-([0-9]+\.[0-9]+\.[0-9]+)-linux-x86_64\.tar\.gz.*'
+	fullVersion="$(curl -fsSL 'https://julialang.org/downloads/' | sed -rn "s!${pattern}!\1!gp")"
+	if [ -z "$fullVersion" ]; then
+		echo >&2 "error: failed to determine latest release for '$version'"
+		exit 1
+	fi
+
+	sha256s="$(curl -fsSL "https://julialang-s3.julialang.org/bin/checksums/julia-${fullVersion}.sha256")"
+
+	linuxArchCase='dpkgArch="$(dpkg --print-architecture)"; '$'\\\n'
+	linuxArchCase+=$'\t''case "${dpkgArch##*-}" in '$'\\\n'
+	for dpkgArch in $(dpkgArches "$version"); do
+		tarArch="$(dpkgToJuliaTarArch "$version" "$dpkgArch")"
+		dirArch="$(dpkgToJuliaDirArch "$version" "$dpkgArch")"
+		sha256="$(echo "$sha256s" | grep "*julia-${fullVersion}-linux-${tarArch}.tar.gz$" | cut -d' ' -f1)"
+		if [ -z "$sha256" ]; then
+			echo >&2 "error: cannot find sha256 for $fullVersion on arch $tarArch / $dirArch ($dpkgArch)"
+			exit 1
+		fi
+		linuxArchCase+=$'\t\t'"$dpkgArch) tarArch='$tarArch'; dirArch='$dirArch'; sha256='$sha256' ;; "$'\\\n'
+	done
+	linuxArchCase+=$'\t\t''*) echo >&2 "error: current architecture ($dpkgArch) does not have a corresponding Julia binary release"; exit 1 ;; '$'\\\n'
+	linuxArchCase+=$'\t''esac'
+
+	echo "$version: $fullVersion"
+
+	sed -r \
+		-e 's!%%JULIA_VERSION%%!'"$fullVersion"'!g' \
+		-e 's!%%ARCH-CASE%%!'"$(sed_escape_rhs "$linuxArchCase")"'!g' \
+		Dockerfile.template > "$version/Dockerfile"
+done


### PR DESCRIPTION
I've successfully tested all three of the arches included here, especially/including `arm32v7`:

```
               _
   _       _ _(_)_     |  A fresh approach to technical computing
  (_)     | (_) (_)    |  Documentation: https://docs.julialang.org
   _ _   _| |_  __ _   |  Type "?help" for help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 0.6.0 (2017-06-19 13:05 UTC)
 _/ |\__'_|_|_|\__'_|  |  Official http://julialang.org/ release
|__/                   |  armv7l-unknown-linux-gnueabihf

```

```diff
$ diff -u <(bashbrew cat julia) <(bashbrew cat <(./generate-stackbrew-library.sh))
--- /dev/fd/63	2017-08-24 14:38:50.974016432 -0700
+++ /dev/fd/62	2017-08-24 14:38:50.975016403 -0700
@@ -2,4 +2,5 @@
 GitRepo: https://github.com/docker-library/julia.git

 Tags: 0.6.0, 0.6, 0, latest
-GitCommit: ef0fdf96ba90c0020776bca367cb838910aca339
+Architectures: amd64, arm32v7, i386
+GitCommit: 4eff23fd0270ed08c727f1ddb10c497559732c22
```

See also docker-library/buildpack-deps#59, docker-library/golang#163, docker-library/docker#63, docker-library/gcc#36, jessfraz/irssi#15, docker-library/redis#95, docker-library/openjdk#121, docker-library/postgres#298, docker-library/haproxy#41, docker-library/httpd#55, docker-library/memcached#19, docker-library/tomcat#73, docker-library/ruby#133, docker-library/python#206, docker-library/php#454, docker-library/wordpress#223, docker-library/rabbitmq#167, docker-library/cassandra#115, docker-library/drupal#90, https://github.com/docker-library/ghost/pull/82.