### PR TITLE
Add stretch variants of 1.2 and 1.3-rc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ matrix:
       env: VERSION=1.3-rc VARIANT=buster ARCH=
     - os: linux
       env: VERSION=1.3-rc VARIANT=buster ARCH=i386
+    - os: linux
+      env: VERSION=1.3-rc VARIANT=stretch ARCH=
+    - os: linux
+      env: VERSION=1.3-rc VARIANT=stretch ARCH=i386
     - os: windows
       dist: 1803-containers
       env: VERSION=1.3-rc VARIANT=windows/windowsservercore-1803
@@ -14,6 +18,10 @@ matrix:
       env: VERSION=1.2 VARIANT=buster ARCH=
     - os: linux
       env: VERSION=1.2 VARIANT=buster ARCH=i386
+    - os: linux
+      env: VERSION=1.2 VARIANT=stretch ARCH=
+    - os: linux
+      env: VERSION=1.2 VARIANT=stretch ARCH=i386
     - os: windows
       dist: 1803-containers
       env: VERSION=1.2 VARIANT=windows/windowsservercore-1803

--- a/1.2/stretch/Dockerfile
+++ b/1.2/stretch/Dockerfile
@@ -1,0 +1,73 @@
+FROM debian:stretch-slim
+
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		ca-certificates \
+# ERROR: no download agent available; install curl, wget, or fetch
+		curl \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+ENV JULIA_PATH /usr/local/julia
+ENV PATH $JULIA_PATH/bin:$PATH
+
+# https://julialang.org/juliareleases.asc
+# Julia (Binary signing key) <buildbot@julialang.org>
+ENV JULIA_GPG 3673DF529D9049477F76B37566E3C7DC03D6E495
+
+# https://julialang.org/downloads/
+ENV JULIA_VERSION 1.2.0
+
+RUN set -eux; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	if ! command -v gpg > /dev/null; then \
+		apt-get update; \
+		apt-get install -y --no-install-recommends \
+			gnupg \
+			dirmngr \
+		; \
+		rm -rf /var/lib/apt/lists/*; \
+	fi; \
+	\
+# https://julialang.org/downloads/#julia-command-line-version
+# https://julialang-s3.julialang.org/bin/checksums/julia-1.2.0.sha256
+# this "case" statement is generated via "update.sh"
+	dpkgArch="$(dpkg --print-architecture)"; \
+	case "${dpkgArch##*-}" in \
+# amd64
+		amd64) tarArch='x86_64'; dirArch='x64'; sha256='926ced5dec5d726ed0d2919e849ff084a320882fb67ab048385849f9483afc47' ;; \
+# arm32v7
+		armhf) tarArch='armv7l'; dirArch='armv7l'; sha256='71d24159f4f08a327c0a2ba8291654121d5f672422cd89bed3966f8df74d33dc' ;; \
+# arm64v8
+		arm64) tarArch='aarch64'; dirArch='aarch64'; sha256='7dab9aa4a320aedb7a4b68c582f9edd434f58867132cb8c6349df25111c3324a' ;; \
+# i386
+		i386) tarArch='i686'; dirArch='x86'; sha256='82f68aed874817cc8f8b49e4f9c391c7911863603528b473900ba51f9067fadd' ;; \
+		*) echo >&2 "error: current architecture ($dpkgArch) does not have a corresponding Julia binary release"; exit 1 ;; \
+	esac; \
+	\
+	folder="$(echo "$JULIA_VERSION" | cut -d. -f1-2)"; \
+	curl -fL -o julia.tar.gz.asc "https://julialang-s3.julialang.org/bin/linux/${dirArch}/${folder}/julia-${JULIA_VERSION}-linux-${tarArch}.tar.gz.asc"; \
+	curl -fL -o julia.tar.gz     "https://julialang-s3.julialang.org/bin/linux/${dirArch}/${folder}/julia-${JULIA_VERSION}-linux-${tarArch}.tar.gz"; \
+	\
+	echo "${sha256} *julia.tar.gz" | sha256sum -c -; \
+	\
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$JULIA_GPG"; \
+	gpg --batch --verify julia.tar.gz.asc julia.tar.gz; \
+	command -v gpgconf > /dev/null && gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" julia.tar.gz.asc; \
+	\
+	mkdir "$JULIA_PATH"; \
+	tar -xzf julia.tar.gz -C "$JULIA_PATH" --strip-components 1; \
+	rm julia.tar.gz; \
+	\
+	apt-mark auto '.*' > /dev/null; \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	\
+# smoke test
+	julia --version
+
+CMD ["julia"]

--- a/1.3-rc/stretch/Dockerfile
+++ b/1.3-rc/stretch/Dockerfile
@@ -1,0 +1,73 @@
+FROM debian:stretch-slim
+
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		ca-certificates \
+# ERROR: no download agent available; install curl, wget, or fetch
+		curl \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+ENV JULIA_PATH /usr/local/julia
+ENV PATH $JULIA_PATH/bin:$PATH
+
+# https://julialang.org/juliareleases.asc
+# Julia (Binary signing key) <buildbot@julialang.org>
+ENV JULIA_GPG 3673DF529D9049477F76B37566E3C7DC03D6E495
+
+# https://julialang.org/downloads/
+ENV JULIA_VERSION 1.3.0-rc2
+
+RUN set -eux; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	if ! command -v gpg > /dev/null; then \
+		apt-get update; \
+		apt-get install -y --no-install-recommends \
+			gnupg \
+			dirmngr \
+		; \
+		rm -rf /var/lib/apt/lists/*; \
+	fi; \
+	\
+# https://julialang.org/downloads/#julia-command-line-version
+# https://julialang-s3.julialang.org/bin/checksums/julia-1.3.0-rc2.sha256
+# this "case" statement is generated via "update.sh"
+	dpkgArch="$(dpkg --print-architecture)"; \
+	case "${dpkgArch##*-}" in \
+# amd64
+		amd64) tarArch='x86_64'; dirArch='x64'; sha256='0d7c6d15567977d4db3588dac7bea14dbcbf0be0c17fe55998aff9727faae549' ;; \
+# arm32v7
+		armhf) tarArch='armv7l'; dirArch='armv7l'; sha256='eb14c84517656978c775488c80ef511d112e59119faf5484c32bee504b06f763' ;; \
+# arm64v8
+		arm64) tarArch='aarch64'; dirArch='aarch64'; sha256='800a9172830ee89bc9c6bbb6d11b49400d51a116e7c2fc2a62c285d8b854cb8e' ;; \
+# i386
+		i386) tarArch='i686'; dirArch='x86'; sha256='609bf5945a6512c72ed2b60751b56b91ca086dd9092b06ce4b0ce9eaa46fd27e' ;; \
+		*) echo >&2 "error: current architecture ($dpkgArch) does not have a corresponding Julia binary release"; exit 1 ;; \
+	esac; \
+	\
+	folder="$(echo "$JULIA_VERSION" | cut -d. -f1-2)"; \
+	curl -fL -o julia.tar.gz.asc "https://julialang-s3.julialang.org/bin/linux/${dirArch}/${folder}/julia-${JULIA_VERSION}-linux-${tarArch}.tar.gz.asc"; \
+	curl -fL -o julia.tar.gz     "https://julialang-s3.julialang.org/bin/linux/${dirArch}/${folder}/julia-${JULIA_VERSION}-linux-${tarArch}.tar.gz"; \
+	\
+	echo "${sha256} *julia.tar.gz" | sha256sum -c -; \
+	\
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$JULIA_GPG"; \
+	gpg --batch --verify julia.tar.gz.asc julia.tar.gz; \
+	command -v gpgconf > /dev/null && gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" julia.tar.gz.asc; \
+	\
+	mkdir "$JULIA_PATH"; \
+	tar -xzf julia.tar.gz -C "$JULIA_PATH" --strip-components 1; \
+	rm julia.tar.gz; \
+	\
+	apt-mark auto '.*' > /dev/null; \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	\
+# smoke test
+	julia --version
+
+CMD ["julia"]

--- a/update.sh
+++ b/update.sh
@@ -75,9 +75,13 @@ for version in "${versions[@]}"; do
 
 		case "$variant" in
 			windowsservercore-*) template='windowsservercore'; tag="${variant#*-}" ;;
-			stretch) template='debian'; tag="${variant}" ;;
 			*) template='debian'; tag="${variant}-slim" ;;
 		esac
+
+		if [ "$version" = '1.0' ] && [ "$template" = 'debian' ] && [ "$variant" = 'stretch' ]; then
+			# 1.0-stretch needs to stay non-slim for backwards compatibility
+			tag="$variant"
+		fi
 
 		sed -r \
 			-e 's!%%JULIA_VERSION%%!'"$fullVersion"'!g' \


### PR DESCRIPTION
Debian Stretch is still officially supported by both the Debian Release and Security teams until "~2020" (and the LTS Team after that until ~2022).

- https://wiki.debian.org/DebianReleases

Closes #35