### PR TITLE
added dockerfile for nvidia cuda

### DIFF
--- a/1.4/cuda/Dockerfile
+++ b/1.4/cuda/Dockerfile
@@ -1,0 +1,104 @@
+ARG UBUNTU_VERSION=18.04
+
+ARG CUDA=10.2
+FROM nvidia/cuda:${CUDA}-base-ubuntu${UBUNTU_VERSION}
+
+ARG CUDA
+ARG CUDNN=8.0.0.180-1
+ARG LIBCUBLAS10=10.2.1.243-1  
+
+SHELL ["/bin/bash", "-c"]
+
+RUN apt-get update && apt-get -y install --no-install-recommends \
+    build-essential \ 
+    cuda-command-line-tools-${CUDA/./-} \
+    libcublas10=${LIBCUBLAS10} \ 
+    cuda-nvrtc-${CUDA/./-} \
+    cuda-cufft-${CUDA/./-} \
+    cuda-curand-${CUDA/./-} \
+    cuda-cusolver-${CUDA/./-} \
+    cuda-cusparse-${CUDA/./-} \
+    curl \
+    libcudnn8=${CUDNN}+cuda${CUDA} \
+    libfreetype6-dev \
+    libhdf5-serial-dev \
+    libzmq3-dev \
+    pkg-config \
+    software-properties-common \
+    unzip \
+    git \
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV LD_LIBRARY_PATH /usr/local/cuda/extras/CUPTI/lib64:/usr/local/cuda/lib64:$LD_LIBRARY_PATH
+
+# create softlink
+RUN ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 \
+    && echo "/usr/local/cuda/lib64/stubs" > /etc/ld.so.conf.d/z-cuda-stubs.conf \
+    && ldconfig      
+
+ENV JULIA_PATH /usr/local/julia
+ENV PATH $JULIA_PATH/bin:$PATH
+
+# # use local cuda installation and not artifact
+ENV JULIA_CUDA_USE_BINARYBUILDER false
+
+# https://julialang.org/juliareleases.asc
+# Julia (Binary signing key) <buildbot@julialang.org>
+ENV JULIA_GPG 3673DF529D9049477F76B37566E3C7DC03D6E495
+
+# https://julialang.org/downloads/
+ENV JULIA_VERSION 1.4.2
+
+RUN set -eux; \
+	savedAptMark="$(apt-mark showmanual)"; \
+	if ! command -v gpg > /dev/null; then \
+		apt-get update; \
+		apt-get install -y --no-install-recommends \
+			gnupg \
+			dirmngr \
+		; \
+		rm -rf /var/lib/apt/lists/*; \
+	fi; \
+	\
+# https://julialang.org/downloads/#julia-command-line-version
+# https://julialang-s3.julialang.org/bin/checksums/julia-1.4.2.sha256
+# this "case" statement is generated via "update.sh"
+	dpkgArch="$(dpkg --print-architecture)"; \
+	case "${dpkgArch##*-}" in \
+# amd64
+		amd64) tarArch='x86_64'; dirArch='x64'; sha256='d77311be23260710e89700d0b1113eecf421d6cf31a9cebad3f6bdd606165c28' ;; \
+# arm64v8
+		arm64) tarArch='aarch64'; dirArch='aarch64'; sha256='f124d1b9fa68c3049d4ffe2349454f8ba1753d17d6578bc6e7cb916aed7cff4a' ;; \
+# i386
+		i386) tarArch='i686'; dirArch='x86'; sha256='ce821b6671a137dc7c2ccbf40ff08471a6791ea8af80a30d6716806608e72dab' ;; \
+		*) echo >&2 "error: current architecture ($dpkgArch) does not have a corresponding Julia binary release"; exit 1 ;; \
+	esac; \
+	\
+	folder="$(echo "$JULIA_VERSION" | cut -d. -f1-2)"; \
+	curl -fL -o julia.tar.gz.asc "https://julialang-s3.julialang.org/bin/linux/${dirArch}/${folder}/julia-${JULIA_VERSION}-linux-${tarArch}.tar.gz.asc"; \
+	curl -fL -o julia.tar.gz     "https://julialang-s3.julialang.org/bin/linux/${dirArch}/${folder}/julia-${JULIA_VERSION}-linux-${tarArch}.tar.gz"; \
+	\
+	echo "${sha256} *julia.tar.gz" | sha256sum -c -; \
+	\
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$JULIA_GPG"; \
+	gpg --batch --verify julia.tar.gz.asc julia.tar.gz; \
+	command -v gpgconf > /dev/null && gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" julia.tar.gz.asc; \
+	\
+	mkdir "$JULIA_PATH"; \
+	tar -xzf julia.tar.gz -C "$JULIA_PATH" --strip-components 1; \
+	rm julia.tar.gz; \
+	\
+	apt-mark auto '.*' > /dev/null; \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+# smoke test
+	julia --version
+
+RUN julia -e 'using Pkg;Pkg.add("CUDA");precompile'
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
This is a docker container for use with cuda/gpu.

To build: docker build . -t julia:gpu
To spin up container with gpu usage: docker run --gpus all -it --rm julia:gpu bash

This does not use the julia cuda artifact but rather the local(in container) cuda installation.
To use local(container) cuda installation the environment variable JULIA_CUDA_USE_BINARYBUILDER is set to false

CUDA examples on CUDA.jl page ran successfully. 