### PR TITLE
Remove explicit `dirmngr` reference

### DIFF
--- a/1.6/alpine3.16/Dockerfile
+++ b/1.6/alpine3.16/Dockerfile
@@ -42,7 +42,7 @@ RUN set -eux; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$JULIA_GPG"; \
 	gpg --batch --verify julia.tar.gz.asc julia.tar.gz; \
-	command -v gpgconf > /dev/null && gpgconf --kill all; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME" julia.tar.gz.asc; \
 	\
 	mkdir "$JULIA_PATH"; \

--- a/1.6/alpine3.17/Dockerfile
+++ b/1.6/alpine3.17/Dockerfile
@@ -42,7 +42,7 @@ RUN set -eux; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$JULIA_GPG"; \
 	gpg --batch --verify julia.tar.gz.asc julia.tar.gz; \
-	command -v gpgconf > /dev/null && gpgconf --kill all; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME" julia.tar.gz.asc; \
 	\
 	mkdir "$JULIA_PATH"; \

--- a/1.6/bullseye/Dockerfile
+++ b/1.6/bullseye/Dockerfile
@@ -28,14 +28,11 @@ ENV JULIA_VERSION 1.6.7
 RUN set -eux; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \
-	if ! command -v gpg > /dev/null; then \
-		apt-get update; \
-		apt-get install -y --no-install-recommends \
-			gnupg \
-			dirmngr \
-		; \
-		rm -rf /var/lib/apt/lists/*; \
-	fi; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		gnupg \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
 	\
 # https://julialang.org/downloads/#julia-command-line-version
 # https://julialang-s3.julialang.org/bin/checksums/julia-1.6.7.sha256
@@ -71,7 +68,7 @@ RUN set -eux; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$JULIA_GPG"; \
 	gpg --batch --verify julia.tar.gz.asc julia.tar.gz; \
-	command -v gpgconf > /dev/null && gpgconf --kill all; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME" julia.tar.gz.asc; \
 	\
 	mkdir "$JULIA_PATH"; \

--- a/1.6/buster/Dockerfile
+++ b/1.6/buster/Dockerfile
@@ -28,14 +28,11 @@ ENV JULIA_VERSION 1.6.7
 RUN set -eux; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \
-	if ! command -v gpg > /dev/null; then \
-		apt-get update; \
-		apt-get install -y --no-install-recommends \
-			gnupg \
-			dirmngr \
-		; \
-		rm -rf /var/lib/apt/lists/*; \
-	fi; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		gnupg \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
 	\
 # https://julialang.org/downloads/#julia-command-line-version
 # https://julialang-s3.julialang.org/bin/checksums/julia-1.6.7.sha256
@@ -71,7 +68,7 @@ RUN set -eux; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$JULIA_GPG"; \
 	gpg --batch --verify julia.tar.gz.asc julia.tar.gz; \
-	command -v gpgconf > /dev/null && gpgconf --kill all; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME" julia.tar.gz.asc; \
 	\
 	mkdir "$JULIA_PATH"; \

--- a/1.8/alpine3.16/Dockerfile
+++ b/1.8/alpine3.16/Dockerfile
@@ -42,7 +42,7 @@ RUN set -eux; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$JULIA_GPG"; \
 	gpg --batch --verify julia.tar.gz.asc julia.tar.gz; \
-	command -v gpgconf > /dev/null && gpgconf --kill all; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME" julia.tar.gz.asc; \
 	\
 	mkdir "$JULIA_PATH"; \

--- a/1.8/alpine3.17/Dockerfile
+++ b/1.8/alpine3.17/Dockerfile
@@ -42,7 +42,7 @@ RUN set -eux; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$JULIA_GPG"; \
 	gpg --batch --verify julia.tar.gz.asc julia.tar.gz; \
-	command -v gpgconf > /dev/null && gpgconf --kill all; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME" julia.tar.gz.asc; \
 	\
 	mkdir "$JULIA_PATH"; \

--- a/1.8/bullseye/Dockerfile
+++ b/1.8/bullseye/Dockerfile
@@ -28,14 +28,11 @@ ENV JULIA_VERSION 1.8.5
 RUN set -eux; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \
-	if ! command -v gpg > /dev/null; then \
-		apt-get update; \
-		apt-get install -y --no-install-recommends \
-			gnupg \
-			dirmngr \
-		; \
-		rm -rf /var/lib/apt/lists/*; \
-	fi; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		gnupg \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
 	\
 # https://julialang.org/downloads/#julia-command-line-version
 # https://julialang-s3.julialang.org/bin/checksums/julia-1.8.5.sha256
@@ -71,7 +68,7 @@ RUN set -eux; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$JULIA_GPG"; \
 	gpg --batch --verify julia.tar.gz.asc julia.tar.gz; \
-	command -v gpgconf > /dev/null && gpgconf --kill all; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME" julia.tar.gz.asc; \
 	\
 	mkdir "$JULIA_PATH"; \

--- a/1.8/buster/Dockerfile
+++ b/1.8/buster/Dockerfile
@@ -28,14 +28,11 @@ ENV JULIA_VERSION 1.8.5
 RUN set -eux; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \
-	if ! command -v gpg > /dev/null; then \
-		apt-get update; \
-		apt-get install -y --no-install-recommends \
-			gnupg \
-			dirmngr \
-		; \
-		rm -rf /var/lib/apt/lists/*; \
-	fi; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		gnupg \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
 	\
 # https://julialang.org/downloads/#julia-command-line-version
 # https://julialang-s3.julialang.org/bin/checksums/julia-1.8.5.sha256
@@ -71,7 +68,7 @@ RUN set -eux; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$JULIA_GPG"; \
 	gpg --batch --verify julia.tar.gz.asc julia.tar.gz; \
-	command -v gpgconf > /dev/null && gpgconf --kill all; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME" julia.tar.gz.asc; \
 	\
 	mkdir "$JULIA_PATH"; \

--- a/1.9-rc/alpine3.16/Dockerfile
+++ b/1.9-rc/alpine3.16/Dockerfile
@@ -42,7 +42,7 @@ RUN set -eux; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$JULIA_GPG"; \
 	gpg --batch --verify julia.tar.gz.asc julia.tar.gz; \
-	command -v gpgconf > /dev/null && gpgconf --kill all; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME" julia.tar.gz.asc; \
 	\
 	mkdir "$JULIA_PATH"; \

--- a/1.9-rc/alpine3.17/Dockerfile
+++ b/1.9-rc/alpine3.17/Dockerfile
@@ -42,7 +42,7 @@ RUN set -eux; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$JULIA_GPG"; \
 	gpg --batch --verify julia.tar.gz.asc julia.tar.gz; \
-	command -v gpgconf > /dev/null && gpgconf --kill all; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME" julia.tar.gz.asc; \
 	\
 	mkdir "$JULIA_PATH"; \

--- a/1.9-rc/bullseye/Dockerfile
+++ b/1.9-rc/bullseye/Dockerfile
@@ -28,14 +28,11 @@ ENV JULIA_VERSION 1.9.0-rc2
 RUN set -eux; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \
-	if ! command -v gpg > /dev/null; then \
-		apt-get update; \
-		apt-get install -y --no-install-recommends \
-			gnupg \
-			dirmngr \
-		; \
-		rm -rf /var/lib/apt/lists/*; \
-	fi; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		gnupg \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
 	\
 # https://julialang.org/downloads/#julia-command-line-version
 # https://julialang-s3.julialang.org/bin/checksums/julia-1.9.0-rc2.sha256
@@ -71,7 +68,7 @@ RUN set -eux; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$JULIA_GPG"; \
 	gpg --batch --verify julia.tar.gz.asc julia.tar.gz; \
-	command -v gpgconf > /dev/null && gpgconf --kill all; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME" julia.tar.gz.asc; \
 	\
 	mkdir "$JULIA_PATH"; \

--- a/1.9-rc/buster/Dockerfile
+++ b/1.9-rc/buster/Dockerfile
@@ -28,14 +28,11 @@ ENV JULIA_VERSION 1.9.0-rc2
 RUN set -eux; \
 	\
 	savedAptMark="$(apt-mark showmanual)"; \
-	if ! command -v gpg > /dev/null; then \
-		apt-get update; \
-		apt-get install -y --no-install-recommends \
-			gnupg \
-			dirmngr \
-		; \
-		rm -rf /var/lib/apt/lists/*; \
-	fi; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		gnupg \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
 	\
 # https://julialang.org/downloads/#julia-command-line-version
 # https://julialang-s3.julialang.org/bin/checksums/julia-1.9.0-rc2.sha256
@@ -71,7 +68,7 @@ RUN set -eux; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$JULIA_GPG"; \
 	gpg --batch --verify julia.tar.gz.asc julia.tar.gz; \
-	command -v gpgconf > /dev/null && gpgconf --kill all; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME" julia.tar.gz.asc; \
 	\
 	mkdir "$JULIA_PATH"; \

--- a/Dockerfile-linux.template
+++ b/Dockerfile-linux.template
@@ -57,14 +57,11 @@ RUN set -eux; \
 	apk add --no-cache --virtual .fetch-deps gnupg; \
 {{ ) else ( -}}
 	savedAptMark="$(apt-mark showmanual)"; \
-	if ! command -v gpg > /dev/null; then \
-		apt-get update; \
-		apt-get install -y --no-install-recommends \
-			gnupg \
-			dirmngr \
-		; \
-		rm -rf /var/lib/apt/lists/*; \
-	fi; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		gnupg \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
 {{ ) end -}}
 	\
 # https://julialang.org/downloads/#julia-command-line-version
@@ -108,7 +105,7 @@ RUN set -eux; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$JULIA_GPG"; \
 	gpg --batch --verify julia.tar.gz.asc julia.tar.gz; \
-	command -v gpgconf > /dev/null && gpgconf --kill all; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME" julia.tar.gz.asc; \
 	\
 	mkdir "$JULIA_PATH"; \


### PR DESCRIPTION
This is pulled in automatically via `gnupg`, and moved from `Recommends` to `Depends` in https://salsa.debian.org/debian/gnupg2/-/commit/99474ad900a8bcdd0e7b68f986fec0013fc01470, which has been part of `src:gnupg2` since 2.1.21-4 (and every supported version of both Debian _and_ Ubuntu have 2.2.x 😇).