### PR TITLE
Add Windows Server 2025 variant

### DIFF
--- a/1.10/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/1.10/windows/windowsservercore-ltsc2025/Dockerfile
@@ -1,0 +1,46 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM mcr.microsoft.com/windows/servercore:ltsc2025
+
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV JULIA_VERSION 1.10.7
+ENV JULIA_URL https://julialang-s3.julialang.org/bin/winnt/x64/1.10/julia-1.10.7-win64.exe
+ENV JULIA_SHA256 51689d4e608fb78468ffabf55fd72896c3f3d84770cf58accb87cd0a57e9cbb8
+
+RUN Write-Host ('Downloading {0} ...' -f $env:JULIA_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $env:JULIA_URL -OutFile 'julia.exe'; \
+	\
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:JULIA_SHA256); \
+	if ((Get-FileHash julia.exe -Algorithm sha256).Hash -ne $env:JULIA_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Installing ...'; \
+	Start-Process -Wait -NoNewWindow \
+		-FilePath '.\julia.exe' \
+		-ArgumentList @( \
+			'/SILENT', \
+			'/DIR=C:\julia' \
+		); \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item julia.exe -Force; \
+	\
+	Write-Host 'Updating PATH ...'; \
+	$env:PATH = 'C:\julia\bin;' + $env:PATH; \
+	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
+	\
+	Write-Host 'Verifying install ("julia --version") ...'; \
+	julia --version; \
+	\
+	Write-Host 'Complete.'
+
+CMD ["julia"]

--- a/1.11/windows/windowsservercore-ltsc2025/Dockerfile
+++ b/1.11/windows/windowsservercore-ltsc2025/Dockerfile
@@ -1,0 +1,46 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM mcr.microsoft.com/windows/servercore:ltsc2025
+
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV JULIA_VERSION 1.11.2
+ENV JULIA_URL https://julialang-s3.julialang.org/bin/winnt/x64/1.11/julia-1.11.2-win64.exe
+ENV JULIA_SHA256 617c6b4d5fadea5ed05cba649377ec7c0c83519da4249c247db5a7812dc6f0c1
+
+RUN Write-Host ('Downloading {0} ...' -f $env:JULIA_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $env:JULIA_URL -OutFile 'julia.exe'; \
+	\
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:JULIA_SHA256); \
+	if ((Get-FileHash julia.exe -Algorithm sha256).Hash -ne $env:JULIA_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Installing ...'; \
+	Start-Process -Wait -NoNewWindow \
+		-FilePath '.\julia.exe' \
+		-ArgumentList @( \
+			'/SILENT', \
+			'/DIR=C:\julia' \
+		); \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item julia.exe -Force; \
+	\
+	Write-Host 'Updating PATH ...'; \
+	$env:PATH = 'C:\julia\bin;' + $env:PATH; \
+	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
+	\
+	Write-Host 'Verifying install ("julia --version") ...'; \
+	julia --version; \
+	\
+	Write-Host 'Complete.'
+
+CMD ["julia"]

--- a/versions.json
+++ b/versions.json
@@ -41,6 +41,7 @@
     "variants": [
       "bookworm",
       "bullseye",
+      "windows/windowsservercore-ltsc2025",
       "windows/windowsservercore-ltsc2022",
       "windows/windowsservercore-1809"
     ],
@@ -94,6 +95,7 @@
       "bullseye",
       "alpine3.21",
       "alpine3.20",
+      "windows/windowsservercore-ltsc2025",
       "windows/windowsservercore-ltsc2022",
       "windows/windowsservercore-1809"
     ],

--- a/versions.sh
+++ b/versions.sh
@@ -110,6 +110,7 @@ for version in "${versions[@]}"; do
 				| "alpine" + .
 			else empty end,
 			if .arches | has("windows-amd64") then
+				"ltsc2025",
 				"ltsc2022",
 				"1809",
 				empty


### PR DESCRIPTION
Add Windows Server ltsc2025; keep 1809 as it is still in extended support (we may drop it later, even while it is supported by Windows).

Refs: https://github.com/docker-library/official-images/pull/18143