### PR TITLE
Add back 1.11.x

### DIFF
--- a/1.11/bookworm/Dockerfile
+++ b/1.11/bookworm/Dockerfile
@@ -1,0 +1,87 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM debian:bookworm-slim
+
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		ca-certificates \
+# ERROR: no download agent available; install curl, wget, or fetch
+		curl \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+ENV JULIA_PATH /usr/local/julia
+ENV PATH $JULIA_PATH/bin:$PATH
+
+# https://julialang.org/juliareleases.asc
+# Julia (Binary signing key) <buildbot@julialang.org>
+ENV JULIA_GPG 3673DF529D9049477F76B37566E3C7DC03D6E495
+
+# https://julialang.org/downloads/
+ENV JULIA_VERSION 1.11.9
+
+RUN set -eux; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		gnupg \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+# https://julialang.org/downloads/#julia-command-line-version
+# https://julialang-s3.julialang.org/bin/checksums/julia-1.11.9.sha256
+	arch="$(dpkg --print-architecture)"; \
+	case "$arch" in \
+		'amd64') \
+			url='https://julialang-s3.julialang.org/bin/linux/x64/1.11/julia-1.11.9-linux-x86_64.tar.gz'; \
+			sha256='b36363356d7a05eaf8b7b9e7a91c710f6bd3d2940be4d4e6d14b9a9f2927de35'; \
+			;; \
+		'i386') \
+			url='https://julialang-s3.julialang.org/bin/linux/x86/1.11/julia-1.11.9-linux-i686.tar.gz'; \
+			sha256='74df5031a93bce45e30582a71bf70f4ba983ff42f6eaf54eb9effb6e124604ca'; \
+			;; \
+		'arm64') \
+			url='https://julialang-s3.julialang.org/bin/linux/aarch64/1.11/julia-1.11.9-linux-aarch64.tar.gz'; \
+			sha256='a2071f0654d1d6af4381cba650b9f790f5f8bb7a570e51e378de8bcf67ff623e'; \
+			;; \
+		'ppc64el') \
+			url='https://julialang-s3.julialang.org/bin/linux/ppc64le/1.11/julia-1.11.9-linux-ppc64le.tar.gz'; \
+			sha256='3c25d5bf70d65da5859d65b34d17646dd1b3f1b50ea2090d13e63171d6dbf861'; \
+			;; \
+		*) \
+			echo >&2 "error: current architecture ($arch) does not have a corresponding Julia binary release"; \
+			exit 1; \
+			;; \
+	esac; \
+	\
+	curl -fL -o julia.tar.gz.asc "$url.asc"; \
+	curl -fL -o julia.tar.gz "$url"; \
+	\
+	echo "$sha256 *julia.tar.gz" | sha256sum --strict --check -; \
+	\
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$JULIA_GPG"; \
+	gpg --batch --verify julia.tar.gz.asc julia.tar.gz; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" julia.tar.gz.asc; \
+	\
+	mkdir "$JULIA_PATH"; \
+	tar -xzf julia.tar.gz -C "$JULIA_PATH" --strip-components 1; \
+	rm julia.tar.gz; \
+	\
+	apt-mark auto '.*' > /dev/null; \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	\
+# smoke test
+	julia --version
+
+COPY docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["julia"]

--- a/1.11/bookworm/docker-entrypoint.sh
+++ b/1.11/bookworm/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eu
+
+# first arg is `-e` or `--some-option` (docker run julia -e '42')
+# ... is a "*.jl" file                 (docker run -v ...:/my/file.jl:ro julia /my/file.jl)
+# ... or there are no args
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ] || [ "${1%.jl}" != "$1" ]; then
+	exec julia "$@"
+fi
+
+exec "$@"

--- a/1.11/trixie/Dockerfile
+++ b/1.11/trixie/Dockerfile
@@ -1,0 +1,87 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM debian:trixie-slim
+
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		ca-certificates \
+# ERROR: no download agent available; install curl, wget, or fetch
+		curl \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+ENV JULIA_PATH /usr/local/julia
+ENV PATH $JULIA_PATH/bin:$PATH
+
+# https://julialang.org/juliareleases.asc
+# Julia (Binary signing key) <buildbot@julialang.org>
+ENV JULIA_GPG 3673DF529D9049477F76B37566E3C7DC03D6E495
+
+# https://julialang.org/downloads/
+ENV JULIA_VERSION 1.11.9
+
+RUN set -eux; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		gnupg \
+	; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+# https://julialang.org/downloads/#julia-command-line-version
+# https://julialang-s3.julialang.org/bin/checksums/julia-1.11.9.sha256
+	arch="$(dpkg --print-architecture)"; \
+	case "$arch" in \
+		'amd64') \
+			url='https://julialang-s3.julialang.org/bin/linux/x64/1.11/julia-1.11.9-linux-x86_64.tar.gz'; \
+			sha256='b36363356d7a05eaf8b7b9e7a91c710f6bd3d2940be4d4e6d14b9a9f2927de35'; \
+			;; \
+		'i386') \
+			url='https://julialang-s3.julialang.org/bin/linux/x86/1.11/julia-1.11.9-linux-i686.tar.gz'; \
+			sha256='74df5031a93bce45e30582a71bf70f4ba983ff42f6eaf54eb9effb6e124604ca'; \
+			;; \
+		'arm64') \
+			url='https://julialang-s3.julialang.org/bin/linux/aarch64/1.11/julia-1.11.9-linux-aarch64.tar.gz'; \
+			sha256='a2071f0654d1d6af4381cba650b9f790f5f8bb7a570e51e378de8bcf67ff623e'; \
+			;; \
+		'ppc64el') \
+			url='https://julialang-s3.julialang.org/bin/linux/ppc64le/1.11/julia-1.11.9-linux-ppc64le.tar.gz'; \
+			sha256='3c25d5bf70d65da5859d65b34d17646dd1b3f1b50ea2090d13e63171d6dbf861'; \
+			;; \
+		*) \
+			echo >&2 "error: current architecture ($arch) does not have a corresponding Julia binary release"; \
+			exit 1; \
+			;; \
+	esac; \
+	\
+	curl -fL -o julia.tar.gz.asc "$url.asc"; \
+	curl -fL -o julia.tar.gz "$url"; \
+	\
+	echo "$sha256 *julia.tar.gz" | sha256sum --strict --check -; \
+	\
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$JULIA_GPG"; \
+	gpg --batch --verify julia.tar.gz.asc julia.tar.gz; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" julia.tar.gz.asc; \
+	\
+	mkdir "$JULIA_PATH"; \
+	tar -xzf julia.tar.gz -C "$JULIA_PATH" --strip-components 1; \
+	rm julia.tar.gz; \
+	\
+	apt-mark auto '.*' > /dev/null; \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	\
+# smoke test
+	julia --version
+
+COPY docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["julia"]

--- a/1.11/trixie/docker-entrypoint.sh
+++ b/1.11/trixie/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eu
+
+# first arg is `-e` or `--some-option` (docker run julia -e '42')
+# ... is a "*.jl" file                 (docker run -v ...:/my/file.jl:ro julia /my/file.jl)
+# ... or there are no args
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ] || [ "${1%.jl}" != "$1" ]; then
+	exec julia "$@"
+fi
+
+exec "$@"

--- a/1.11/windows/servercore-ltsc2022/Dockerfile
+++ b/1.11/windows/servercore-ltsc2022/Dockerfile
@@ -1,0 +1,46 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
+
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV JULIA_VERSION 1.11.9
+ENV JULIA_URL https://julialang-s3.julialang.org/bin/winnt/x64/1.11/julia-1.11.9-win64.exe
+ENV JULIA_SHA256 747ff8983fa183e0e35e618c9212815cba0b3ad29a44eaac039acc755a0d91b6
+
+RUN Write-Host ('Downloading {0} ...' -f $env:JULIA_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $env:JULIA_URL -OutFile 'julia.exe'; \
+	\
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:JULIA_SHA256); \
+	if ((Get-FileHash julia.exe -Algorithm sha256).Hash -ne $env:JULIA_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Installing ...'; \
+	Start-Process -Wait -NoNewWindow \
+		-FilePath '.\julia.exe' \
+		-ArgumentList @( \
+			'/SILENT', \
+			'/DIR=C:\julia' \
+		); \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item julia.exe -Force; \
+	\
+	Write-Host 'Updating PATH ...'; \
+	$env:PATH = 'C:\julia\bin;' + $env:PATH; \
+	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
+	\
+	Write-Host 'Verifying install ("julia --version") ...'; \
+	julia --version; \
+	\
+	Write-Host 'Complete.'
+
+CMD ["julia"]

--- a/1.11/windows/servercore-ltsc2025/Dockerfile
+++ b/1.11/windows/servercore-ltsc2025/Dockerfile
@@ -1,0 +1,46 @@
+#
+# NOTE: THIS DOCKERFILE IS GENERATED VIA "apply-templates.sh"
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+FROM mcr.microsoft.com/windows/servercore:ltsc2025
+
+# $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+ENV JULIA_VERSION 1.11.9
+ENV JULIA_URL https://julialang-s3.julialang.org/bin/winnt/x64/1.11/julia-1.11.9-win64.exe
+ENV JULIA_SHA256 747ff8983fa183e0e35e618c9212815cba0b3ad29a44eaac039acc755a0d91b6
+
+RUN Write-Host ('Downloading {0} ...' -f $env:JULIA_URL); \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -Uri $env:JULIA_URL -OutFile 'julia.exe'; \
+	\
+	Write-Host ('Verifying sha256 ({0}) ...' -f $env:JULIA_SHA256); \
+	if ((Get-FileHash julia.exe -Algorithm sha256).Hash -ne $env:JULIA_SHA256) { \
+		Write-Host 'FAILED!'; \
+		exit 1; \
+	}; \
+	\
+	Write-Host 'Installing ...'; \
+	Start-Process -Wait -NoNewWindow \
+		-FilePath '.\julia.exe' \
+		-ArgumentList @( \
+			'/SILENT', \
+			'/DIR=C:\julia' \
+		); \
+	\
+	Write-Host 'Removing ...'; \
+	Remove-Item julia.exe -Force; \
+	\
+	Write-Host 'Updating PATH ...'; \
+	$env:PATH = 'C:\julia\bin;' + $env:PATH; \
+	[Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine); \
+	\
+	Write-Host 'Verifying install ("julia --version") ...'; \
+	julia --version; \
+	\
+	Write-Host 'Complete.'
+
+CMD ["julia"]

--- a/versions.json
+++ b/versions.json
@@ -95,6 +95,53 @@
       "windows/servercore-ltsc2022"
     ]
   },
+  "1.11": {
+    "version": "1.11.9",
+    "arches": {
+      "amd64": {
+        "url": "https://julialang-s3.julialang.org/bin/linux/x64/1.11/julia-1.11.9-linux-x86_64.tar.gz",
+        "sha256": "b36363356d7a05eaf8b7b9e7a91c710f6bd3d2940be4d4e6d14b9a9f2927de35"
+      },
+      "i386": {
+        "url": "https://julialang-s3.julialang.org/bin/linux/x86/1.11/julia-1.11.9-linux-i686.tar.gz",
+        "sha256": "74df5031a93bce45e30582a71bf70f4ba983ff42f6eaf54eb9effb6e124604ca"
+      },
+      "arm64v8": {
+        "url": "https://julialang-s3.julialang.org/bin/linux/aarch64/1.11/julia-1.11.9-linux-aarch64.tar.gz",
+        "sha256": "a2071f0654d1d6af4381cba650b9f790f5f8bb7a570e51e378de8bcf67ff623e"
+      },
+      "ppc64le": {
+        "url": "https://julialang-s3.julialang.org/bin/linux/ppc64le/1.11/julia-1.11.9-linux-ppc64le.tar.gz",
+        "sha256": "3c25d5bf70d65da5859d65b34d17646dd1b3f1b50ea2090d13e63171d6dbf861"
+      },
+      "darwin-amd64": {
+        "url": "https://julialang-s3.julialang.org/bin/mac/x64/1.11/julia-1.11.9-mac64.tar.gz",
+        "sha256": "f7b49c3ddb22389dfab2c1d8d26fa4bef540ee8195650d8c502daa9c1c2edf92"
+      },
+      "darwin-arm64v8": {
+        "url": "https://julialang-s3.julialang.org/bin/mac/aarch64/1.11/julia-1.11.9-macaarch64.tar.gz",
+        "sha256": "ed903d0d337036fc3a68414bfca5f73107af162678ef76b52e42e84e25f33bd7"
+      },
+      "windows-amd64": {
+        "url": "https://julialang-s3.julialang.org/bin/winnt/x64/1.11/julia-1.11.9-win64.exe",
+        "sha256": "747ff8983fa183e0e35e618c9212815cba0b3ad29a44eaac039acc755a0d91b6"
+      },
+      "windows-i386": {
+        "url": "https://julialang-s3.julialang.org/bin/winnt/x86/1.11/julia-1.11.9-win32.exe",
+        "sha256": "cf083fe27e5dd9293175708625bb5d911250e29a6b7e8ecd95852228ffc6d66f"
+      },
+      "freebsd-amd64": {
+        "url": "https://julialang-s3.julialang.org/bin/freebsd/x64/1.11/julia-1.11.9-freebsd-x86_64.tar.gz",
+        "sha256": "275c0bc46f50b58a584a30f29fda20b757b8f6a1dff4cf664b0168724ff3d373"
+      }
+    },
+    "variants": [
+      "trixie",
+      "bookworm",
+      "windows/servercore-ltsc2025",
+      "windows/servercore-ltsc2022"
+    ]
+  },
   "rc": {
     "version": "1.13.0-beta2",
     "arches": {


### PR DESCRIPTION
It seems to not really be end of life (though I'm unsure of when it _will_ be EOL and can be removed again 😵‍💫). It has had releases since we removed it with the latest being just two days ago (https://github.com/JuliaLang/julia/releases/tag/v1.11.9).

Fixes https://github.com/docker-library/julia/issues/102

It was removed in https://github.com/docker-library/julia/pull/100